### PR TITLE
fetch news from server

### DIFF
--- a/lib/graphql/news.dart
+++ b/lib/graphql/news.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class News {
+  final String id;
+  final String date;
+  final String message;
+  final String messageJa;
+  final String link;
+
+  News({this.id, this.date, this.message, this.messageJa, this.link});
+
+  factory News.fromJson(Map<String, dynamic> json) {
+    return News(
+      id: json['id'],
+      date: json['date'],
+      message: json['message'],
+      messageJa: json['messageJa'],
+      link: json['link'],
+    );
+  }
+}
+
+Future<List<News>> fetchNews() {
+  return _client.post(_url, body: json.encode({
+    'query': _query,
+  }))
+    .then((response) => _parseJSON(response))
+    // エラーが起きたらデフォルトのやつを表示しておく
+    .catchError(() => [
+      News(
+        date: '2018-09-04',
+        id: '1',
+        link: 'https://techconf.mercari.com/2018',
+        messageJa: 'Mercari Tech Conf 2018のWebページが公開されました。',
+        message: 'Mercari Tech Conf 2018のWebページが公開されました。'
+      ),
+    ]);
+}
+
+String _url = 'https://techconf.mercari.com/2018/api/query';
+http.Client _client = http.Client();
+String _query = """
+  {
+    newsList {
+      nodes {
+        id
+        date
+        message
+        messageJa
+        link
+      }
+    }
+  }
+""";
+
+List<News> _parseJSON(http.Response response) {
+  var decoded = json.decode(utf8.decode(response.bodyBytes));
+  List<dynamic> nodes = decoded['data']['newsList']['nodes'];
+  return nodes.map((n) => News.fromJson(n)).toList();
+}

--- a/lib/page/news_page.dart
+++ b/lib/page/news_page.dart
@@ -1,7 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:mtc2018_app/graphql/news.dart';
 import '../colors.dart';
 
-class NewsPage extends StatelessWidget {
+class NewsPage extends StatefulWidget {
+  const NewsPage({ Key key }) : super(key: key);
+
+  @override
+  _NewsPageState createState() => new _NewsPageState();
+}
+class _NewsPageState extends State<NewsPage> {
+  List<News> newsList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    fetchNews().then((newsList) {
+      this.setState(() {
+        this.newsList = newsList;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,7 +29,7 @@ class NewsPage extends StatelessWidget {
       ),
       body: ListView(
         padding: EdgeInsets.all(16.0),
-        children: [
+        children: this.newsList.map((news) => 
           Card(
               color: Colors.white,
               child: Container(
@@ -26,26 +45,25 @@ class NewsPage extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                'Webページが公開されました',
+                                news.messageJa,
                                 style: TextStyle(
                                     fontSize: 16.0,
                                     color: kMtcPrimaryGrey,
                                     fontWeight: FontWeight.bold),
                               ),
                               Container(height: 4.0),
-                              Text('2018/08/29',
+                              Text(news.date,
                                   style: TextStyle(
                                       fontSize: 12.0, color: kMtcPrimaryGrey))
                             ])
                       ],
                     ),
                     Container(height: 12.0),
-                    Text("Mercari Tech Conf 2018のWebページが公開されました。",
+                    Text(news.messageJa,
                         style: TextStyle(color: kMtcPrimaryGrey)),
                   ],
                 ),
-              ))
-        ],
+              ))).toList(),
       ),
     );
   }


### PR DESCRIPTION
GraphQLサーバーからニュースを取得する

- MTC2018用のAPIサーバーはそのうちクローズするので、APIアクセスがエラーになってもいいようにしておく
- https://pub.dartlang.org/packages/graphql_flutter が使えそうだったがレスポンスをUTF-8でデコードしないと文字化けする。うまいことやればいけそうだけど諦めてHTTPでアクセスする